### PR TITLE
Add a list of educational sources

### DIFF
--- a/Education materials.md
+++ b/Education materials.md
@@ -1,0 +1,81 @@
+Energy-meteorology education materials
+Prepared for the Next Generation Challenges in Energy Climate Modelling Workshop, 2021 Lead by Hannah Bloomfield, Katharina Gruber and Jan Wohland, with support from the conference
+organising committee.
+The global need to reverse the damage to the planet done by humans over multiple centuries is provoking a rapid change in the way we interact with the planet. One of the main challenges here is a change in how national energy systems operate. Generally these systems are attempting to reduce their reliance of fossil fuels (like coal, oil and natural gas), which release green-house gases including carbon dioxide. These green house gases are very damaging to the planet, and a leading cause of global warming. Instead of using fossil fuels many nations are turning instead to renewable electricity generation, powered by natural resources such as wind, sunshine or water. This has led to the development of a new scientific discipline - energy meteorology!
+When conducting research in this area (or just entering the topic with an interest to learn more) it is very rare to have equal levels of knowledge on both the energy and meteorology components of the subject. The following resources are therefore intended to help provide introductory material for both the fields of energy and meteorology and the combined field of energy-meteorology.
+We have tried to limit these to bitesize information videos (~5 minutes). Some useful, but slightly longer online webinars or conference talks from energy-meteorologists are given in italics. Advanced materials and opportunities to download data and start your own research are given at the end of the document.
+Note: The links to these external resources are provided on an ‘as is’ basis. While it is hoped that you may find the links useful when beginning to explore topics in energy-meteorology before and after the workshop, this document is not intended to be an exhaustive list or resources, nor does inclusion on the list necessarily imply an endorsement of the content.
+ 
+Meteorology General:
+An introduction to weather and climate: https://www.youtube.com/watch?v=lB0dpDNcXpY
+How does the climate system work? https://www.youtube.com/watch?v=lrPS2HiYVp8&list=PLGVVqeJodR_bqVT3iXTRNQ9gIUjuXIEvK&index=21
+What is the jet stream and how does it work? https://www.youtube.com/watch?v=huweohIh_Bw&list=PLGVVqeJodR_bqVT3iXTRNQ9gIUjuXIEvK&index=24
+An introduction to the Global circulation: 3 part YouTube introduction by the UK Met Office. [link] What is ElNino? https://www.youtube.com/watch?v=7fd03fBRsuU
+What is the North Atlantic Oscillation? https://www.youtube.com/watch?v=KOYJG7j4Iy8 
+
+## Past meteorological data
+What is a reanalysis dataset? https://www.youtube.com/watch?v=FAGobvUGl24
+Why do we use long time series of data in energy-meteorology? https://www.youtube.com/watch?v=EPlUxH_om0w&list=PLGBIeEHEJD9HDXpS5F244TNeSWoCKBtGc&index=6
+Background meteorological datasets used in energy-meteorology (weather forecasts, reanalysis and climate models (first 20 mins of video - long introduction!). https://www.youtube.com/watch?v=zp320W6xCAk&list=PLGBIeEHEJD9HDXpS5F244TNeSWoCKBtGc&index=2
+
+
+## Future climate data
+What is climate change? https://www.youtube.com/watch?v=ffjIyms1BX4
+
+<!-- TODO an update is needed -->
+Reflections on 2020, the hottest year ever https://www.youtube.com/watch?v=14hS-iTNLp8
+An introduction to climate projections: Covers what a climate model is, how it differs from a weather forecasting model. Some examples of future projections data and the uncertainties associated with them. https://www.youtube.com/watch?v=GU5kx1silwE&list=PLB7XYEK5KkhqbkO7YyhfgdrWVQ2MBe_mJ&index=2 (longer video)
+Uncertainty in future climate change projections [link] This is a 4-part video series looking at the meteorological uncertainties https://www.youtube.com/watch?v=RUrR6zDm8j0&list=PLB7XYEK5KkhpfOZUaoi3ka61oeURq2WMc&index=14
+Weather forecasts
+How do meteorologists predict the weather? https://www.youtube.com/watch?v=LlWCStJ3BCU 
+How do we monitor the weather from space? https://www.youtube.com/watch?v=zfVeB4s8WWk&list=PLOQg9n6Apif2QUccFbT0RQoT08ggibEoD&index=2 
+What is data assimilation? https://www.youtube.com/watch?v=YPAWYjPf_Pk
+ 
+# Energy systems
+What is an energy system? https://www.youtube.com/watch?v=-HAux6J2YeY 
+Overview of electric power systems https://www.youtube.com/watch?v=Ul1ZlxAKsh8
+
+## Energy system transitions
+Understanding the energy transition https://www.youtube.com/watch?v=U2dUwmXMLpw
+How might energy systems change by 2050 https://www.youtube.com/watch?v=-k6c_z8YfxQ
+Do we need nuclear energy to stop climate change? https://www.youtube.com/watch?v=EhAemz1v7dQ&list=PLFs4vir_WsTyXrrpFstD64Qj95vpy-yo1
+Is it too late to stop climate change? https://www.youtube.com/watch?v=wbR-5mHI6bo
+Can 100% renewable energy power the world? https://www.youtube.com/watch?v=RnvCbquYeIM
+European energy grids: Future plans for electrification and flexibility https://www.youtube.com/watch?v=EnsMjlalukk
+
+## Weather dependence in power systems
+The use of weather data in power systems modelling https://www.youtube.com/watch?v=zp320W6xCAk&list=PLGBIeEHEJD9HDXpS5F244TNeSWoCKBtGc&index=2
+
+## Energy systems models
+Energy system models explained https://www.youtube.com/watch?v=QGW73VHjJFQ
+Assisting energy planning with bias corrected energy projections https://www.youtube.com/watch?v=fEKE64qeUFE&list=PLB7XYEK5KkhqbkO7YyhfgdrWVQ2MBe_mJ&index=11 (longer video)
+
+# Advanced Learning Resources
+If you already have a bit more knowledge some advanced learning materials are given below
+
+## Meteorology
+Basics of climate variability and change https://www.youtube.com/watch?v=gZAemBi3RA8
+An Introduction to Atmospheric Dynamics lecture course is given here: https://www.youtube.com/channel/UCrm3Nkw_0wPJxjOolmZe5iA
+
+## Energy
+Sustainable Energy: Design a renewable future online course https://online-learning.tudelft.nl/courses/sustainable-energy-design-a-renewable-future/
+The OpenMod learning materials: https://wiki.openmod-initiative.org/wiki/Learning_materials
+Sustainable Energy Lecture Course: covers a lot of useful energy related topics https://www.youtube.com/playlist?list=PLxTFLzYie40pndQG7QBVczKNZST3dGenQ
+Open energy system modelling for climate scientists and others https://www.youtube.com/watch?v=-dk3CVzaGew
+
+## Energy Meteorology
+A selection of books on the topic of energy meteorology can be found here: https://www.wemcouncil.org/wp/resources/#1569332431001-52a5603d-0e9d
+
+The current challenges in energy are outlined in a summary of a recent meeting of experts. A list of useful books on the topic are given here:
+
+## Opportunities to Download weather, climate and energy data.
+There are loads of time series of data available out there that you can download here https://forum.openmod-initiative.org/t/freely-available-datasets-of-energy-variables/2291 and start to play with. Or if for now you’d rather just look at some data here are some websites which allow you to explore climate and energy data:
+TealTool: https://tealtool.earth/ This is the best starting point for visualising climate data relevant for energy systems modelling. TealTool is a free climate data tool designed to raise awareness about climate change. You can look at national level weather data from across the globe and look at different timescales
+ECEM demonstrator: http://ecem.wemcouncil.org/ This also shows weather data of a present and future climate. The difference from the TealTool is you can also look at energy variables (e.g. electricity demand, wind power, solar power and hydropower.) The ECEM demonstrator is limited to over Europe.
+
+<!-- TODO Update for  -->
+Raw climate data can be downloaded from the Copernicus Climate data store, there are instructions for how to use their python API https://cds.climate.copernicus.eu/
+
+If you’re interested in creating your own seasonal forecasts' multi-model with Python and C3S the this could be useful: http://www.matteodefelice.name/post/c3s-multimodel/
+If you would like to try running your own energy systems model with a simple setup: https://github.com/ahilbers/calliope
+    

--- a/Education materials.md
+++ b/Education materials.md
@@ -1,4 +1,4 @@
-Energy-meteorology education materials
+# Energy-meteorology education materials
 Prepared for the Next Generation Challenges in Energy Climate Modelling Workshop, 2021 Lead by Hannah Bloomfield, Katharina Gruber and Jan Wohland, with support from the conference
 organising committee.
 The global need to reverse the damage to the planet done by humans over multiple centuries is provoking a rapid change in the way we interact with the planet. One of the main challenges here is a change in how national energy systems operate. Generally these systems are attempting to reduce their reliance of fossil fuels (like coal, oil and natural gas), which release green-house gases including carbon dioxide. These green house gases are very damaging to the planet, and a leading cause of global warming. Instead of using fossil fuels many nations are turning instead to renewable electricity generation, powered by natural resources such as wind, sunshine or water. This has led to the development of a new scientific discipline - energy meteorology!
@@ -6,36 +6,37 @@ When conducting research in this area (or just entering the topic with an intere
 We have tried to limit these to bitesize information videos (~5 minutes). Some useful, but slightly longer online webinars or conference talks from energy-meteorologists are given in italics. Advanced materials and opportunities to download data and start your own research are given at the end of the document.
 Note: The links to these external resources are provided on an ‘as is’ basis. While it is hoped that you may find the links useful when beginning to explore topics in energy-meteorology before and after the workshop, this document is not intended to be an exhaustive list or resources, nor does inclusion on the list necessarily imply an endorsement of the content.
  
-Meteorology General:
+## Meteorology General:
 An introduction to weather and climate: https://www.youtube.com/watch?v=lB0dpDNcXpY
 How does the climate system work? https://www.youtube.com/watch?v=lrPS2HiYVp8&list=PLGVVqeJodR_bqVT3iXTRNQ9gIUjuXIEvK&index=21
 What is the jet stream and how does it work? https://www.youtube.com/watch?v=huweohIh_Bw&list=PLGVVqeJodR_bqVT3iXTRNQ9gIUjuXIEvK&index=24
 An introduction to the Global circulation: 3 part YouTube introduction by the UK Met Office. [link] What is ElNino? https://www.youtube.com/watch?v=7fd03fBRsuU
 What is the North Atlantic Oscillation? https://www.youtube.com/watch?v=KOYJG7j4Iy8 
 
-## Past meteorological data
+### Past meteorological data
 What is a reanalysis dataset? https://www.youtube.com/watch?v=FAGobvUGl24
 Why do we use long time series of data in energy-meteorology? https://www.youtube.com/watch?v=EPlUxH_om0w&list=PLGBIeEHEJD9HDXpS5F244TNeSWoCKBtGc&index=6
 Background meteorological datasets used in energy-meteorology (weather forecasts, reanalysis and climate models (first 20 mins of video - long introduction!). https://www.youtube.com/watch?v=zp320W6xCAk&list=PLGBIeEHEJD9HDXpS5F244TNeSWoCKBtGc&index=2
 
 
-## Future climate data
+### Future climate data
 What is climate change? https://www.youtube.com/watch?v=ffjIyms1BX4
 
 <!-- TODO an update is needed -->
 Reflections on 2020, the hottest year ever https://www.youtube.com/watch?v=14hS-iTNLp8
 An introduction to climate projections: Covers what a climate model is, how it differs from a weather forecasting model. Some examples of future projections data and the uncertainties associated with them. https://www.youtube.com/watch?v=GU5kx1silwE&list=PLB7XYEK5KkhqbkO7YyhfgdrWVQ2MBe_mJ&index=2 (longer video)
 Uncertainty in future climate change projections [link] This is a 4-part video series looking at the meteorological uncertainties https://www.youtube.com/watch?v=RUrR6zDm8j0&list=PLB7XYEK5KkhpfOZUaoi3ka61oeURq2WMc&index=14
-Weather forecasts
+
+### Weather forecasts
 How do meteorologists predict the weather? https://www.youtube.com/watch?v=LlWCStJ3BCU 
 How do we monitor the weather from space? https://www.youtube.com/watch?v=zfVeB4s8WWk&list=PLOQg9n6Apif2QUccFbT0RQoT08ggibEoD&index=2 
 What is data assimilation? https://www.youtube.com/watch?v=YPAWYjPf_Pk
  
-# Energy systems
+## Energy systems
 What is an energy system? https://www.youtube.com/watch?v=-HAux6J2YeY 
 Overview of electric power systems https://www.youtube.com/watch?v=Ul1ZlxAKsh8
 
-## Energy system transitions
+### Energy system transitions
 Understanding the energy transition https://www.youtube.com/watch?v=U2dUwmXMLpw
 How might energy systems change by 2050 https://www.youtube.com/watch?v=-k6c_z8YfxQ
 Do we need nuclear energy to stop climate change? https://www.youtube.com/watch?v=EhAemz1v7dQ&list=PLFs4vir_WsTyXrrpFstD64Qj95vpy-yo1
@@ -43,27 +44,27 @@ Is it too late to stop climate change? https://www.youtube.com/watch?v=wbR-5mHI6
 Can 100% renewable energy power the world? https://www.youtube.com/watch?v=RnvCbquYeIM
 European energy grids: Future plans for electrification and flexibility https://www.youtube.com/watch?v=EnsMjlalukk
 
-## Weather dependence in power systems
+### Weather dependence in power systems
 The use of weather data in power systems modelling https://www.youtube.com/watch?v=zp320W6xCAk&list=PLGBIeEHEJD9HDXpS5F244TNeSWoCKBtGc&index=2
 
-## Energy systems models
+### Energy systems models
 Energy system models explained https://www.youtube.com/watch?v=QGW73VHjJFQ
 Assisting energy planning with bias corrected energy projections https://www.youtube.com/watch?v=fEKE64qeUFE&list=PLB7XYEK5KkhqbkO7YyhfgdrWVQ2MBe_mJ&index=11 (longer video)
 
-# Advanced Learning Resources
+## Advanced Learning Resources
 If you already have a bit more knowledge some advanced learning materials are given below
 
-## Meteorology
+### Meteorology
 Basics of climate variability and change https://www.youtube.com/watch?v=gZAemBi3RA8
 An Introduction to Atmospheric Dynamics lecture course is given here: https://www.youtube.com/channel/UCrm3Nkw_0wPJxjOolmZe5iA
 
-## Energy
+### Energy
 Sustainable Energy: Design a renewable future online course https://online-learning.tudelft.nl/courses/sustainable-energy-design-a-renewable-future/
 The OpenMod learning materials: https://wiki.openmod-initiative.org/wiki/Learning_materials
 Sustainable Energy Lecture Course: covers a lot of useful energy related topics https://www.youtube.com/playlist?list=PLxTFLzYie40pndQG7QBVczKNZST3dGenQ
 Open energy system modelling for climate scientists and others https://www.youtube.com/watch?v=-dk3CVzaGew
 
-## Energy Meteorology
+### Energy Meteorology
 A selection of books on the topic of energy meteorology can be found here: https://www.wemcouncil.org/wp/resources/#1569332431001-52a5603d-0e9d
 
 The current challenges in energy are outlined in a summary of a recent meeting of experts. A list of useful books on the topic are given here:


### PR DESCRIPTION
Adding a draft of the `Energy-meteorology education materials` prepared for NextGenEC 2021 and available [here](https://research.reading.ac.uk/met-energy/next-generation-challenges-workshop/next-generation-energy-climate-modelling-2021/). Currently, that is just an original pdf version translated into markdown. 

@matteodefelice does the idea to add the list to the repo sound reasonable for you? My feeling is that it would be perfect to collect all the materials under one roof, but not sure if it corresponds to your vision of the architecture of the repo. Let me know please if you have any concerns or comments