### PR TITLE
Change format of the path

### DIFF
--- a/notebooks/C.005.ipynb
+++ b/notebooks/C.005.ipynb
@@ -670,7 +670,7 @@
    ],
    "source": [
     "\n",
-    "ds = xr.open_dataset('..\\data\\era5-u100_v100_201903.grib')\n",
+    "ds = xr.open_dataset('../data/era5-u100_v100_201903.grib')\n",
     "ds = ds.assign({'ws100': (ds['u100']**2 + ds['v100']**2)**0.5})\n",
     "ds"
    ]


### PR DESCRIPTION
Change path delimiters in `C.005` to the ones used in the other notebooks. It resolves some troubles on Mac, but haven't been tested on Windows